### PR TITLE
Envelope center srid

### DIFF
--- a/lib/geo_ruby/simple_features/envelope.rb
+++ b/lib/geo_ruby/simple_features/envelope.rb
@@ -50,7 +50,7 @@ module GeoRuby
 
       #Sends back the center of the envelope
       def center
-        Point.from_x_y((lower_corner.x + upper_corner.x)/2,(lower_corner.y + upper_corner.y)/2)
+        Point.from_x_y((lower_corner.x + upper_corner.x)/2,(lower_corner.y + upper_corner.y)/2, srid)
       end
 
       #Zoom level

--- a/spec/geo_ruby/simple_features/envelope_spec.rb
+++ b/spec/geo_ruby/simple_features/envelope_spec.rb
@@ -2,7 +2,8 @@ require File.expand_path(File.dirname(__FILE__) + '/../../spec_helper')
 
 describe Envelope do
   before(:each) do
-    @env = Envelope.from_points([Point.from_x_y(10,20),Point.from_x_y(20,30)])
+    @srid = 4269
+    @env = Envelope.from_points([Point.from_x_y(10,20, @srid),Point.from_x_y(20,30, @srid)], @srid)
   end
 
   it "should initialize" do
@@ -36,6 +37,7 @@ describe Envelope do
   it "should have a center" do
     @env.center.x.should eql(15)
     @env.center.y.should eql(25)
+    @env.center.srid.should eql(@env.srid)
   end
 
   it "should print a kml_representation" do


### PR DESCRIPTION
Envelope#center wasn't remembering the SRID of the envelope.  This fixes that bug.
