### PR TITLE
Optional json

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,6 @@ begin
     gem.email = "georuby@simplitex.com"
     gem.homepage = "http://github.com/nofxx/georuby"
     gem.authors = ["Guilhem Vellut", "Marcos Piccinini", "Marcus Mateus", "Doug Cole"]
-    gem.add_runtime_dependency "json_pure", ">=1.4.6"
     gem.add_development_dependency "rspec", ">= 2.0.0"
     gem.add_development_dependency "dbf", ">= 1.2.9"
   end

--- a/lib/geo_ruby.rb
+++ b/lib/geo_ruby.rb
@@ -16,8 +16,8 @@ require 'geo_ruby/simple_features/geometry_collection'
 require 'geo_ruby/simple_features/envelope'
 require 'geo_ruby/simple_features/geometry_factory'
 require 'geo_ruby/simple_features/georss_parser'
-require 'geo_ruby/simple_features/geojson_parser'
 
 # Include if you need
 # require 'geo_ruby/shp4r/shp'
 # require 'geo_ruby/gpx4r/gpx'
+# require 'geo_ruby/simple_features/geojson_parser'


### PR DESCRIPTION
This is a breaking change to current functionality, but I'd like to be able to use this version of georuby without the json_pure dependency since we don't use geojson in our app at all and already depend on a different json gem.  We could also add begin/rescue blocks to allow the user to use their choice of json gems with geojson (we use yajl-ruby in our app) and add back in the require line in 'lib/geo_ruby'.  Let me know what you prefer.
