### PR TITLE
Fix for DBF column names where downcase is different from underscore

### DIFF
--- a/lib/geo_ruby/shp4r/dbf.rb
+++ b/lib/geo_ruby/shp4r/dbf.rb
@@ -15,7 +15,7 @@ module GeoRuby
     module Dbf
       class Record
         def [](v)
-          attributes[v.downcase]
+          attributes[v]
         end
       end
 


### PR DESCRIPTION
The Dbf::Record monkey patch uses [] to access the prettified name in the attributes hash (assumed to be the column name downcased).  The DBF gem actually underscores it.  This breaks for some column names (e.g., "ZCTA5CE".underscore == "zcta5_ce").  Furthermore, it is unnecessary as the attributes hash also contains the original column name: https://github.com/infused/dbf/blob/master/lib/dbf/attributes.rb#L2-5.
