### PR TITLE
as_json support

### DIFF
--- a/lib/geo_ruby/geojson.rb
+++ b/lib/geo_ruby/geojson.rb
@@ -23,13 +23,17 @@ module GeoRuby
       end
     end
 
-    def to_json(options={})
+    def as_json(options={})
       output = {}
       output[:type] = 'Feature'
       output[:geometry] = geometry
       output[:properties] = properties
       output[:id] = id unless id.nil?
       output.to_json(options)
+    end
+
+    def to_json(options = {})
+      as_json(options).to_json
     end
     alias :as_geojson :to_json
   end

--- a/lib/geo_ruby/simple_features/geometry_collection.rb
+++ b/lib/geo_ruby/simple_features/geometry_collection.rb
@@ -102,11 +102,15 @@ module GeoRuby
         "GEOMETRYCOLLECTION"
       end
 
+      def as_json(options = {})
+        {:type => 'GeometryCollection',
+         :geometries => self.geometries}
+      end
+
       # simple geojson representation
       # TODO add CRS / SRID support?
       def to_json(options = {})
-        {:type => 'GeometryCollection',
-         :geometries => self.geometries}.to_json(options)
+        as_json(options).to_json(options)
       end
       alias :as_geojson :to_json
 

--- a/lib/geo_ruby/simple_features/line_string.rb
+++ b/lib/geo_ruby/simple_features/line_string.rb
@@ -202,11 +202,15 @@ module GeoRuby
         points.map{|p| p.to_coordinates }
       end
 
+      def as_json(options = {})
+        {:type => 'LineString',
+         :coordinates => self.to_coordinates}
+      end
+
       # simple geojson representation
       # TODO add CRS / SRID support?
       def to_json(options = {})
-        {:type => 'LineString',
-         :coordinates => self.to_coordinates}.to_json(options)
+        as_json(options).to_json(options)
       end
       alias :as_geojson :to_json
 

--- a/lib/geo_ruby/simple_features/multi_line_string.rb
+++ b/lib/geo_ruby/simple_features/multi_line_string.rb
@@ -37,11 +37,15 @@ module GeoRuby
         geometries.map{|ls| ls.to_coordinates}
       end
 
+      def as_json(options = {})
+        {:type => 'MultiLineString',
+         :coordinates => self.to_coordinates}
+      end
+
       # simple geojson representation
       # TODO add CRS / SRID support?
       def to_json(options = {})
-        {:type => 'MultiLineString',
-         :coordinates => self.to_coordinates}.to_json(options)
+        as_json(options).to_json(options)
       end
       alias :as_geojson :to_json
       

--- a/lib/geo_ruby/simple_features/multi_point.rb
+++ b/lib/geo_ruby/simple_features/multi_point.rb
@@ -31,11 +31,15 @@ module GeoRuby
         points.map{|p| p.to_coordinates }
       end
 
+      def as_json(options = {})
+        {:type => 'MultiPoint',
+         :coordinates => self.to_coordinates}
+      end
+
       # simple geojson representation
       # TODO add CRS / SRID support?
       def to_json(options = {})
-        {:type => 'MultiPoint',
-         :coordinates => self.to_coordinates}.to_json(options)
+        as_json(options).to_json(options)
       end
       alias :as_geojson :to_json
 

--- a/lib/geo_ruby/simple_features/multi_polygon.rb
+++ b/lib/geo_ruby/simple_features/multi_polygon.rb
@@ -35,11 +35,15 @@ module GeoRuby
         geometries.map{|polygon| polygon.to_coordinates}
       end
 
+      def as_json(options = {})
+        {:type => 'MultiPolygon',
+         :coordinates => self.to_coordinates}
+      end
+
       # simple geojson representation
       # TODO add CRS / SRID support?
       def to_json(options = {})
-        {:type => 'MultiPolygon',
-         :coordinates => self.to_coordinates}.to_json(options)
+        as_json(options).to_json(options)
       end
       alias :as_geojson :to_json
 

--- a/lib/geo_ruby/simple_features/point.rb
+++ b/lib/geo_ruby/simple_features/point.rb
@@ -296,11 +296,15 @@ module GeoRuby
         end
       end
 
+      def as_json(options = {})
+        {:type => 'Point',
+         :coordinates => self.to_coordinates}
+      end
+
       # simple geojson representation
       # TODO add CRS / SRID support?
       def to_json(options = {})
-        {:type => 'Point',
-         :coordinates => self.to_coordinates}.to_json(options)
+        as_json(options).to_json(options)
       end
       alias :as_geojson :to_json
     

--- a/lib/geo_ruby/simple_features/polygon.rb
+++ b/lib/geo_ruby/simple_features/polygon.rb
@@ -139,11 +139,15 @@ module GeoRuby
         rings.map{|lr| lr.to_coordinates}
       end
 
+      def as_json(options = {})
+        {:type => 'Polygon',
+         :coordinates => self.to_coordinates}
+      end
+
       # simple geojson representation
       # TODO add CRS / SRID support?
       def to_json(options = {})
-        {:type => 'Polygon',
-         :coordinates => self.to_coordinates}.to_json(options)
+        as_json(options).to_json(options)
       end
       alias :as_geojson :to_json
 


### PR DESCRIPTION
to_json in ActiveSupport now looks for `as_json` which should convert the object into a json compatible format. Without this Rails 3.x will ignore the to_json methods in georuby and try to do it's best guess at a json format based on attributes.

Assuming anyone is using this already with Rails 3.x, this will change their json output. For the better, but it is still potentially a breaking change.
