### PR TITLE
move Gemfile development dependencies into gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,3 @@
 source :rubygems
 
-group :development do
-  gem "dbf", ">= 1.7.0"
-  gem "fastercsv", ">=1.5.5"
-  gem 'json', ">= 1.6.5"
-  gem "rspec", ">= 2.3.0"
-  gem "bundler", ">= 1.0.0"
-  #gem "rcov", ">= 0"
-end
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,8 @@
+PATH
+  remote: .
+  specs:
+    georuby (1.9.8)
+
 GEM
   remote: http://rubygems.org/
   specs:
@@ -6,6 +11,7 @@ GEM
     diff-lcs (1.1.3)
     fastercsv (1.5.5)
     json (1.7.5)
+    nokogiri (1.5.5)
     rspec (2.11.0)
       rspec-core (~> 2.11.0)
       rspec-expectations (~> 2.11.0)
@@ -19,8 +25,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (>= 1.0.0)
   dbf (>= 1.7.0)
-  fastercsv (>= 1.5.5)
+  georuby!
   json (>= 1.6.5)
+  nokogiri (~> 1.5.5)
   rspec (>= 2.3.0)

--- a/georuby.gemspec
+++ b/georuby.gemspec
@@ -20,7 +20,8 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.rubygems_version = %q{1.3.7}
 
-  s.add_development_dependency(%q<dbf>, [">= 1.2.9"])
-  s.add_development_dependency(%q<rspec>, [">= 2.0.0"])
+  s.add_development_dependency "nokogiri", ["~> 1.5.5"]
+  s.add_development_dependency "dbf", ">= 1.7.0"
+  s.add_development_dependency 'json', ">= 1.6.5"
+  s.add_development_dependency "rspec", ">= 2.3.0"
 end
-


### PR DESCRIPTION
I noticed the gemspec dependencies were different from the Gemfile dependencies.

I merged and had the Gemfile reference the gemspec.

Let me know if you want different, and I can change accordingly

Thanks,
Keenan
