### PR TITLE
fix gpx file parsing

### DIFF
--- a/lib/geo_ruby/gpx.rb
+++ b/lib/geo_ruby/gpx.rb
@@ -73,7 +73,7 @@ module GeoRuby
       # If the GPX isn't closed, a line from the first
       # to the last point will be created to close it.
       def as_polygon
-        GeoRuby::SimpleFeatures::Polygon.from_points([@points[0] == @points[-1] ?  @points : @points.push(@points[0].clone)])
+        GeoRuby::SimpleFeatures::Polygon.from_points([@points[0] == @points[-1] ?  @points : (@points + [@points[0].clone])])
       end
 
       # Return GPX Envelope

--- a/spec/geo_ruby/gpx_spec.rb
+++ b/spec/geo_ruby/gpx_spec.rb
@@ -34,6 +34,11 @@ describe GeoRuby::Gpx4r do
       expect(@gpxfile[0].y).to be_within(0.0001).of(48.731813)
     end
 
+    it 'should point last record to last waypoint' do
+      expect(@gpxfile[-1].x).to be_within(0.0001).of(9.09436)
+      expect(@gpxfile[-1].y).to be_within(0.0001).of(48.731805)
+    end
+
     it 'should read Z and M' do
       expect(@gpxfile[0].z).to eql(468.0)
       expect(@gpxfile[0].m).to eql('2008-09-07T17:36:57Z')


### PR DESCRIPTION
`to_polygon` always closes the list of parsed
GPX points inside the GPXFile object.
Since it is used while parsing the GPX file it always
resulted in a closed list of GPX points even if that
was not the case.