### PR TITLE
Fixed reading of SHP with degenerated polygons, NullShape class added.

### DIFF
--- a/lib/geo_ruby/shp4r/shp.rb
+++ b/lib/geo_ruby/shp4r/shp.rb
@@ -204,25 +204,29 @@ module GeoRuby
           # geometry = GeoRuby::SimpleFeatures::MultiPolygon.from_polygons([GeoRuby::SimpleFeatures::Polygon.from_linear_rings(linear_rings)])
           outer, inner = linear_rings.partition(&:clockwise?)
 
-          # Make polygons from the outer rings so we can concatenate
-          # them with inner rings.
-          outer.map! { |ring| GeoRuby::SimpleFeatures::Polygon.from_linear_rings([ring]) }
+          # Return NullShape if polygon is degenerated (it only contains 3 points or less)
+          if outer.empty?
+            geometry = GeoRuby::SimpleFeatures::NullShape.new
+          else
+            # Make polygons from the outer rings so we can concatenate
+            # them with inner rings.
+            outer.map! {|ring| GeoRuby::SimpleFeatures::Polygon.from_linear_rings([ring])}
 
-          # We make the assumption that all vertices of holes are
-          # entirely contained.
-          inner.each do |inner_ring|
-            outer_poly = outer.find { |outer_poly| outer_poly[0].contains_point?(inner_ring[0]) }
-            if outer_poly
-              outer_poly << inner_ring
-            else
-              # TODO - what to do here?  technically the geometry is
-              # not well formed (or our above assumption does not
-              # hold).
-              $stderr.puts 'Failed to find polygon for inner ring!'
+            # We make the assumption that all vertices of holes are
+            # entirely contained.
+            inner.each do |inner_ring|
+              outer_poly = outer.find {|outer_poly| outer_poly[0].contains_point?(inner_ring[0])}
+              if outer_poly
+                outer_poly << inner_ring
+              else
+                # TODO - what to do here?  technically the geometry is
+                # not well formed (or our above assumption does not
+                # hold).
+                puts 'Failed to find polygon for inner ring!'
+              end
             end
+            geometry = GeoRuby::SimpleFeatures::MultiPolygon.from_polygons(outer)
           end
-
-          geometry = GeoRuby::SimpleFeatures::MultiPolygon.from_polygons(outer)
         when ShpType::MULTIPOINT
           @shp.seek(32, IO::SEEK_CUR)
           num_points = @shp.read(4).unpack('V')[0]

--- a/lib/geo_ruby/simple_features.rb
+++ b/lib/geo_ruby/simple_features.rb
@@ -13,6 +13,7 @@ module GeoRuby
       multi_point
       multi_polygon
       point
+      null_shape
       polygon
     ).each do |rel_file|
       require File.join(File.dirname(__FILE__), 'simple_features', rel_file)

--- a/lib/geo_ruby/simple_features/null_shape.rb
+++ b/lib/geo_ruby/simple_features/null_shape.rb
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+require 'geo_ruby/simple_features/geometry'
+
+module GeoRuby
+	module SimpleFeatures
+		# Represents Null Shape. This might come handy when dealing with degenerated
+		# polygons.
+		class NullShape < Geometry
+			# Return empty coordinates and type when called as_json.
+			def as_json(_options = {})
+				{ type: 'NullShape', coordinates: [] }
+			end
+		end
+	end
+end
+


### PR DESCRIPTION
- Added null object (ESRI's 0 according to [specs](https://www.esri.com/library/whitepapers/pdfs/shapefile.pdf ) - page 4) when polygons have no outer face definition (clockwise).