### PR TITLE
Fix/Adding private validation method.

### DIFF
--- a/lib/geo_ruby/simple_features/linear_ring.rb
+++ b/lib/geo_ruby/simple_features/linear_ring.rb
@@ -25,7 +25,7 @@ module GeoRuby
         crossings =
           tuples.select do |a, b|
             valid_point?(a, b) &&
-            (b.y > y != a.y > y) && (x < (a.x - b.x) * (y - b.y) / (a.y - b.y) + b.x)
+              (b.y > y != a.y > y) && (x < (a.x - b.x) * (y - b.y) / (a.y - b.y) + b.x)
           end
 
         crossings.size % 2 == 1
@@ -35,7 +35,7 @@ module GeoRuby
 
       def valid_point?(x_coodinate, y_coordinate)
         x_coodinate.x.present? && x_coodinate.y.present? &&
-        y_coordinate.x.present? && y_coordinate.y.present?
+          y_coordinate.x.present? && y_coordinate.y.present?
       end
     end
   end

--- a/lib/geo_ruby/simple_features/linear_ring.rb
+++ b/lib/geo_ruby/simple_features/linear_ring.rb
@@ -10,7 +10,7 @@ module GeoRuby
       end
 
       # fix kml export
-      alias_method :orig_kml_representation, :kml_representation
+      alias orig_kml_representation kml_representation
       def kml_representation(options = {})
         orig_kml_representation(options).gsub('LineString', 'LinearRing')
       end
@@ -20,16 +20,17 @@ module GeoRuby
       #
       # http://www.ecse.rpi.edu/Homepages/wrf/Research/Short_Notes/pnpoly.html
       def contains_point?(point)
-        x, y = point.x, point.y
+        x = point.x
+        y = point.y
         tuples = @points.zip(@points[1..-1] + [@points[0]])
         crossings =
           tuples.select do |a, b|
             valid_point?(a, b) &&
               (b.y > y != a.y > y) &&
-                (x < (a.x - b.x) * (y - b.y) / (a.y - b.y) + b.x)
+              (x < (a.x - b.x) * (y - b.y) / (a.y - b.y) + b.x)
           end
 
-        crossings.size % 2 == 1
+        crossings.size.odd?
       end
 
       private

--- a/lib/geo_ruby/simple_features/linear_ring.rb
+++ b/lib/geo_ruby/simple_features/linear_ring.rb
@@ -24,7 +24,8 @@ module GeoRuby
         tuples = @points.zip(@points[1..-1] + [@points[0]])
         crossings =
           tuples.select do |a, b|
-            valid_point?(a, b) && (b.y > y != a.y > y) && (x < (a.x - b.x) * (y - b.y) / (a.y - b.y) + b.x)
+            valid_point?(a, b) &&
+            (b.y > y != a.y > y) && (x < (a.x - b.x) * (y - b.y) / (a.y - b.y) + b.x)
           end
 
         crossings.size % 2 == 1
@@ -33,7 +34,8 @@ module GeoRuby
       private
 
       def valid_point?(x_coodinate, y_coordinate)
-        x_coodinate.x.present? && x_coodinate.y.present? && y_coordinate.x.present? && y_coordinate.y.present?
+        x_coodinate.x.present? && x_coodinate.y.present? &&
+        y_coordinate.x.present? && y_coordinate.y.present?
       end
     end
   end

--- a/lib/geo_ruby/simple_features/linear_ring.rb
+++ b/lib/geo_ruby/simple_features/linear_ring.rb
@@ -25,7 +25,8 @@ module GeoRuby
         crossings =
           tuples.select do |a, b|
             valid_point?(a, b) &&
-              (b.y > y != a.y > y) && (x < (a.x - b.x) * (y - b.y) / (a.y - b.y) + b.x)
+              (b.y > y != a.y > y) &&
+                (x < (a.x - b.x) * (y - b.y) / (a.y - b.y) + b.x)
           end
 
         crossings.size % 2 == 1

--- a/lib/geo_ruby/simple_features/linear_ring.rb
+++ b/lib/geo_ruby/simple_features/linear_ring.rb
@@ -32,8 +32,8 @@ module GeoRuby
 
       private
 
-      def valid_point?(a, b)
-        a.x.present? && a.y.present? && b.x.present? && b.y.present?
+      def valid_point?(x_coodinate, y_coordinate)
+        x_coodinate.x.present? && x_coodinate.y.present? && y_coordinate.x.present? && y_coordinate.y.present?
       end
     end
   end

--- a/lib/geo_ruby/simple_features/linear_ring.rb
+++ b/lib/geo_ruby/simple_features/linear_ring.rb
@@ -24,10 +24,16 @@ module GeoRuby
         tuples = @points.zip(@points[1..-1] + [@points[0]])
         crossings =
           tuples.select do |a, b|
-            (b.y > y != a.y > y) && (x < (a.x - b.x) * (y - b.y) / (a.y - b.y) + b.x)
+            valid_point?(a, b) && (b.y > y != a.y > y) && (x < (a.x - b.x) * (y - b.y) / (a.y - b.y) + b.x)
           end
 
         crossings.size % 2 == 1
+      end
+
+      private
+
+      def valid_point?(a, b)
+        a.x.present? && a.y.present? && b.x.present? && b.y.present?
       end
     end
   end


### PR DESCRIPTION
Adding validate_point? method to check for existent coordinates.
I've got this error using [WhereTZ](https://github.com/zverok/wheretz). The same has this library as a dependency.
```
6: from /var/www/backend/vendor/bundle/ruby/2.5.0/gems/georuby-2.5.2/lib/geo_ruby/simple_features/polygon.rb:97:in `contains_point?'
        5: from /var/www/backend/vendor/bundle/ruby/2.5.0/gems/georuby-2.5.2/lib/geo_ruby/simple_features/polygon.rb:97:in `select'
        4: from /var/www/backend/vendor/bundle/ruby/2.5.0/gems/georuby-2.5.2/lib/geo_ruby/simple_features/polygon.rb:97:in `block in contains_point?'
        3: from /var/www/backend/vendor/bundle/ruby/2.5.0/gems/georuby-2.5.2/lib/geo_ruby/simple_features/linear_ring.rb:26:in `contains_point?'
        2: from /var/www/backend/vendor/bundle/ruby/2.5.0/gems/georuby-2.5.2/lib/geo_ruby/simple_features/linear_ring.rb:26:in `select'
        1: from /var/www/backend/vendor/bundle/ruby/2.5.0/gems/georuby-2.5.2/lib/geo_ruby/simple_features/linear_ring.rb:27:in `block in contains_point?'
NoMethodError (undefined method `>' for nil:NilClass)
```
We get some `nil` values for this call. That's why the validation.