### PR TITLE
Don't close GPX polylines

### DIFF
--- a/lib/geo_ruby/gpx.rb
+++ b/lib/geo_ruby/gpx.rb
@@ -73,7 +73,7 @@ module GeoRuby
       # If the GPX isn't closed, a line from the first
       # to the last point will be created to close it.
       def as_polygon
-        GeoRuby::SimpleFeatures::Polygon.from_points([@points[0] == @points[-1] ?  @points : @points.push(@points[0].clone)])
+        GeoRuby::SimpleFeatures::Polygon.from_points([@points[0] == @points[-1] ?  @points : (@points + [@points[0]])])
       end
 
       # Return GPX Envelope


### PR DESCRIPTION
Currently the `as_polygon` method uses `Array.push` to add an extra point to close the shape.

`Array.push` does of course modify the original array in-place. Since `as_polygon` is called by `envelope`, and `envelope` is called by `parse_file`, this means all polylines are erroneously turned into closed polygons on parsing.

This PR fixes this by using `+` instead of `Array.push`.